### PR TITLE
Change comments for heap traversal

### DIFF
--- a/STL/priority_queue.cpp
+++ b/STL/priority_queue.cpp
@@ -34,7 +34,7 @@ int main() {
     // size: O(1)
     cout << pq.size() << endl;  // 출력: 2
 
-    // 순회 (힙의 순서대로, 정렬된 순서가 아님): O(n)
+    // 힙의 우선순위에 따라 순회 : O(n)
     while(!pq.empty()) {
         cout << pq.top() << " ";  // 출력: 3 1
         pq.pop();


### PR DESCRIPTION
`priority_queue`는 별도로 내부 원소들을 확인할 수 있는 방법을 지원하지 않고,
해당 코드는 `heap`을 통해 `heap sort`를 구현하는 내용 같습니다.